### PR TITLE
Supporting darwin/macports

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,18 @@ from distutils.extension import Extension
 from Cython.Distutils import build_ext
 
 import numpy
+import os
 import sys
 
-if sys.platform in ("linux2", "darwin") or "freebsd" in sys.platform:
+if sys.platform == "darwin":
+    if os.path.exists("/opt/local/include/ta-lib"):
+        include_talib_dir = "/opt/local/include"
+        lib_talib_dir = "/opt/local/lib"
+    else:
+        include_talib_dir = "/usr/local/include/"
+        lib_talib_dir = "/usr/local/lib/"
+
+elif sys.platform == "linux2" or "freebsd" in sys.platform:
     include_talib_dir = "/usr/local/include/"
     lib_talib_dir = "/usr/local/lib/"
 


### PR DESCRIPTION
setup.py of v0.4.0 forces the talib include and lib dir to /usr/local/include and /usr/local/lib. MacPorts installs files to /opt/local, so the compiler can never find the headers and libs. This change checks if /opt/local/include/ta-lib exists and uses /opt/local/... instead of /usr/local/... If this does not exist, /usr/local/... is taken by default.

Can you release a new version to pypi with these changes? Thank you!
