### PR TITLE
Possible Bug fix. Hard linked the includes for ta-lib.

### DIFF
--- a/talib/abstract.c
+++ b/talib/abstract.c
@@ -256,10 +256,10 @@
 #include "stdlib.h"
 #include "numpy/arrayobject.h"
 #include "numpy/ufuncobject.h"
-#include "ta-lib/ta_defs.h"
-#include "ta-lib/ta_common.h"
-#include "ta-lib/ta_abstract.h"
-#include "ta-lib/ta_func.h"
+#include "C:/ta-lib/c/include/ta_defs.h"
+#include "C:/ta-lib/c/include/ta_common.h"
+#include "C:/ta-lib/c/include/ta_abstract.h"
+#include "C:/ta-lib/c/include/ta_func.h"
 #ifdef _OPENMP
 #include <omp.h>
 #endif /* _OPENMP */


### PR DESCRIPTION
![ss](https://f.cloud.github.com/assets/1977636/330693/d0575fb0-9bd4-11e2-88f2-83289ba50d70.PNG)
I couldn't get ta-lib to compile on windows, so I modified the includes
to be hard linked to the C:/ta-lib/c/include directory. (My platform is
windows 7)
