### PR TITLE
Provide at least one user writable path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,9 @@ for prefix in ['darwin', 'linux', 'bsd']:
             '/usr/local/include',
             '/opt/include',
             '/opt/local/include',
-            os.path.expanduser('~/opt/include'),
         ]
+        if 'TA_INCLUDE_PATH' in os.environ:
+            include_dirs.append(os.environ['TA_INCLUDE_PATH'])
         lib_talib_dirs = [
             '/usr/lib',
             '/usr/local/lib',
@@ -42,6 +43,8 @@ for prefix in ['darwin', 'linux', 'bsd']:
             '/opt/local/lib',
             os.path.expanduser('~/opt/lib'),
         ]
+        if 'TA_LIBRARY_PATH' in os.environ:
+            include_dirs.append(os.environ['TA_LIBRARY_PATH'])
         break
 
 if sys.platform == "win32":

--- a/setup.py
+++ b/setup.py
@@ -41,10 +41,9 @@ for prefix in ['darwin', 'linux', 'bsd']:
             '/usr/local/lib64',
             '/opt/lib',
             '/opt/local/lib',
-            os.path.expanduser('~/opt/lib'),
         ]
         if 'TA_LIBRARY_PATH' in os.environ:
-            include_dirs.append(os.environ['TA_LIBRARY_PATH'])
+            lib_talib_dirs.append(os.environ['TA_LIBRARY_PATH'])
         break
 
 if sys.platform == "win32":

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ for prefix in ['darwin', 'linux', 'bsd']:
             '/usr/local/include',
             '/opt/include',
             '/opt/local/include',
+            '/home/travis/opt/include',
         ]
         lib_talib_dirs = [
             '/usr/lib',
@@ -39,6 +40,7 @@ for prefix in ['darwin', 'linux', 'bsd']:
             '/usr/local/lib64',
             '/opt/lib',
             '/opt/local/lib',
+            '/home/travis/opt/lib',
         ]
         break
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ for prefix in ['darwin', 'linux', 'bsd']:
             '/usr/local/include',
             '/opt/include',
             '/opt/local/include',
-            '/home/travis/opt/include',
+            os.path.expanduser('~/opt/include'),
         ]
         lib_talib_dirs = [
             '/usr/lib',
@@ -40,7 +40,7 @@ for prefix in ['darwin', 'linux', 'bsd']:
             '/usr/local/lib64',
             '/opt/lib',
             '/opt/local/lib',
-            '/home/travis/opt/lib',
+            os.path.expanduser('~/opt/lib'),
         ]
         break
 


### PR DESCRIPTION
This PR adds the `~/opt` prefix to the paths where the `talib` can be found. It is useful to be able to install the C library on systems without admin (`sudo`) rights.

I don't care what the final prefix will be or if we want to make it somehow configurable (env variable?), so feel free to suggest other ways to add that path. :-)