### PR TITLE
update documentation to warn about unstable functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+docs/html
+docs/.tadoc.org.html
+
 *.pyc
 build
 *.so

--- a/docs/func_groups/cycle_indicators.md
+++ b/docs/func_groups/cycle_indicators.md
@@ -1,30 +1,35 @@
 # Cycle Indicator Functions
 ### HT_DCPERIOD - Hilbert Transform - Dominant Cycle Period
-```
+NOTE: The ``HT_DCPERIOD`` function has an unstable period.  
+```python
 real = HT_DCPERIOD(close)
 ```
 
 Learn more about the Hilbert Transform - Dominant Cycle Period at [tadoc.org](http://www.tadoc.org/indicator/HT_DCPERIOD.htm).  
 ### HT_DCPHASE - Hilbert Transform - Dominant Cycle Phase
-```
+NOTE: The ``HT_DCPHASE`` function has an unstable period.  
+```python
 real = HT_DCPHASE(close)
 ```
 
 Learn more about the Hilbert Transform - Dominant Cycle Phase at [tadoc.org](http://www.tadoc.org/indicator/HT_DCPHASE.htm).  
 ### HT_PHASOR - Hilbert Transform - Phasor Components
-```
+NOTE: The ``HT_PHASOR`` function has an unstable period.  
+```python
 inphase, quadrature = HT_PHASOR(close)
 ```
 
 Learn more about the Hilbert Transform - Phasor Components at [tadoc.org](http://www.tadoc.org/indicator/HT_PHASOR.htm).  
 ### HT_SINE - Hilbert Transform - SineWave
-```
+NOTE: The ``HT_SINE`` function has an unstable period.  
+```python
 sine, leadsine = HT_SINE(close)
 ```
 
 Learn more about the Hilbert Transform - SineWave at [tadoc.org](http://www.tadoc.org/indicator/HT_SINE.htm).  
 ### HT_TRENDMODE - Hilbert Transform - Trend vs Cycle Mode
-```
+NOTE: The ``HT_TRENDMODE`` function has an unstable period.  
+```python
 integer = HT_TRENDMODE(close)
 ```
 

--- a/docs/func_groups/math_operators.md
+++ b/docs/func_groups/math_operators.md
@@ -1,56 +1,56 @@
 # Math Operator Functions
 ### ADD - Vector Arithmetic Add
-```
+```python
 real = ADD(high, low)
 ```
 
 ### DIV - Vector Arithmetic Div
-```
+```python
 real = DIV(high, low)
 ```
 
 ### MAX - Highest value over a specified period
-```
+```python
 real = MAX(close, timeperiod=30)
 ```
 
 ### MAXINDEX - Index of highest value over a specified period
-```
+```python
 integer = MAXINDEX(close, timeperiod=30)
 ```
 
 ### MIN - Lowest value over a specified period
-```
+```python
 real = MIN(close, timeperiod=30)
 ```
 
 ### MININDEX - Index of lowest value over a specified period
-```
+```python
 integer = MININDEX(close, timeperiod=30)
 ```
 
 ### MINMAX - Lowest and highest values over a specified period
-```
+```python
 min, max = MINMAX(close, timeperiod=30)
 ```
 
 ### MINMAXINDEX - Indexes of lowest and highest values over a specified period
-```
+```python
 minidx, maxidx = MINMAXINDEX(close, timeperiod=30)
 ```
 
 ### MULT - Vector Arithmetic Mult
-```
+```python
 real = MULT(high, low)
 ```
 
 ### SUB - Vector Arithmetic Substraction
-```
+```python
 real = SUB(high, low)
 ```
 
 ### SUM - Summation
-```
+```python
 real = SUM(close, timeperiod=30)
 ```
 

--- a/docs/func_groups/math_transform.md
+++ b/docs/func_groups/math_transform.md
@@ -1,76 +1,76 @@
 # Math Transform Functions
 ### ACOS - Vector Trigonometric ACos
-```
+```python
 real = ACOS(close)
 ```
 
 ### ASIN - Vector Trigonometric ASin
-```
+```python
 real = ASIN(close)
 ```
 
 ### ATAN - Vector Trigonometric ATan
-```
+```python
 real = ATAN(close)
 ```
 
 ### CEIL - Vector Ceil
-```
+```python
 real = CEIL(close)
 ```
 
 ### COS - Vector Trigonometric Cos
-```
+```python
 real = COS(close)
 ```
 
 ### COSH - Vector Trigonometric Cosh
-```
+```python
 real = COSH(close)
 ```
 
 ### EXP - Vector Arithmetic Exp
-```
+```python
 real = EXP(close)
 ```
 
 ### FLOOR - Vector Floor
-```
+```python
 real = FLOOR(close)
 ```
 
 ### LN - Vector Log Natural
-```
+```python
 real = LN(close)
 ```
 
 ### LOG10 - Vector Log10
-```
+```python
 real = LOG10(close)
 ```
 
 ### SIN - Vector Trigonometric Sin
-```
+```python
 real = SIN(close)
 ```
 
 ### SINH - Vector Trigonometric Sinh
-```
+```python
 real = SINH(close)
 ```
 
 ### SQRT - Vector Square Root
-```
+```python
 real = SQRT(close)
 ```
 
 ### TAN - Vector Trigonometric Tan
-```
+```python
 real = TAN(close)
 ```
 
 ### TANH - Vector Trigonometric Tanh
-```
+```python
 real = TANH(close)
 ```
 

--- a/docs/func_groups/momentum_indicators.md
+++ b/docs/func_groups/momentum_indicators.md
@@ -1,178 +1,189 @@
 # Momentum Indicator Functions
 ### ADX - Average Directional Movement Index
-```
+NOTE: The ``ADX`` function has an unstable period.  
+```python
 real = ADX(high, low, close, timeperiod=14)
 ```
 
 Learn more about the Average Directional Movement Index at [tadoc.org](http://www.tadoc.org/indicator/ADX.htm).  
 ### ADXR - Average Directional Movement Index Rating
-```
+NOTE: The ``ADXR`` function has an unstable period.  
+```python
 real = ADXR(high, low, close, timeperiod=14)
 ```
 
 Learn more about the Average Directional Movement Index Rating at [tadoc.org](http://www.tadoc.org/indicator/ADXR.htm).  
 ### APO - Absolute Price Oscillator
-```
+```python
 real = APO(close, fastperiod=12, slowperiod=26, matype=0)
 ```
 
 Learn more about the Absolute Price Oscillator at [tadoc.org](http://www.tadoc.org/indicator/APO.htm).  
 ### AROON - Aroon
-```
+```python
 aroondown, aroonup = AROON(high, low, timeperiod=14)
 ```
 
 Learn more about the Aroon at [tadoc.org](http://www.tadoc.org/indicator/AROON.htm).  
 ### AROONOSC - Aroon Oscillator
-```
+```python
 real = AROONOSC(high, low, timeperiod=14)
 ```
 
 Learn more about the Aroon Oscillator at [tadoc.org](http://www.tadoc.org/indicator/AROONOSC.htm).  
 ### BOP - Balance Of Power
-```
+```python
 real = BOP(open, high, low, close)
 ```
 
 Learn more about the Balance Of Power at [tadoc.org](http://www.tadoc.org/indicator/BOP.htm).  
 ### CCI - Commodity Channel Index
-```
+```python
 real = CCI(high, low, close, timeperiod=14)
 ```
 
 Learn more about the Commodity Channel Index at [tadoc.org](http://www.tadoc.org/indicator/CCI.htm).  
 ### CMO - Chande Momentum Oscillator
-```
+NOTE: The ``CMO`` function has an unstable period.  
+```python
 real = CMO(close, timeperiod=14)
 ```
 
 Learn more about the Chande Momentum Oscillator at [tadoc.org](http://www.tadoc.org/indicator/CMO.htm).  
 ### DX - Directional Movement Index
-```
+NOTE: The ``DX`` function has an unstable period.  
+```python
 real = DX(high, low, close, timeperiod=14)
 ```
 
 Learn more about the Directional Movement Index at [tadoc.org](http://www.tadoc.org/indicator/DX.htm).  
 ### MACD - Moving Average Convergence/Divergence
-```
+```python
 macd, macdsignal, macdhist = MACD(close, fastperiod=12, slowperiod=26, signalperiod=9)
 ```
 
 Learn more about the Moving Average Convergence/Divergence at [tadoc.org](http://www.tadoc.org/indicator/MACD.htm).  
 ### MACDEXT - MACD with controllable MA type
-```
+```python
 macd, macdsignal, macdhist = MACDEXT(close, fastperiod=12, fastmatype=0, slowperiod=26, slowmatype=0, signalperiod=9, signalmatype=0)
 ```
 
 ### MACDFIX - Moving Average Convergence/Divergence Fix 12/26
-```
+```python
 macd, macdsignal, macdhist = MACDFIX(close, signalperiod=9)
 ```
 
 ### MFI - Money Flow Index
-```
+NOTE: The ``MFI`` function has an unstable period.  
+```python
 real = MFI(high, low, close, volume, timeperiod=14)
 ```
 
 Learn more about the Money Flow Index at [tadoc.org](http://www.tadoc.org/indicator/MFI.htm).  
 ### MINUS_DI - Minus Directional Indicator
-```
+NOTE: The ``MINUS_DI`` function has an unstable period.  
+```python
 real = MINUS_DI(high, low, close, timeperiod=14)
 ```
 
 Learn more about the Minus Directional Indicator at [tadoc.org](http://www.tadoc.org/indicator/MINUS_DI.htm).  
 ### MINUS_DM - Minus Directional Movement
-```
+NOTE: The ``MINUS_DM`` function has an unstable period.  
+```python
 real = MINUS_DM(high, low, timeperiod=14)
 ```
 
 Learn more about the Minus Directional Movement at [tadoc.org](http://www.tadoc.org/indicator/MINUS_DM.htm).  
 ### MOM - Momentum
-```
+```python
 real = MOM(close, timeperiod=10)
 ```
 
 Learn more about the Momentum at [tadoc.org](http://www.tadoc.org/indicator/MOM.htm).  
 ### PLUS_DI - Plus Directional Indicator
-```
+NOTE: The ``PLUS_DI`` function has an unstable period.  
+```python
 real = PLUS_DI(high, low, close, timeperiod=14)
 ```
 
 Learn more about the Plus Directional Indicator at [tadoc.org](http://www.tadoc.org/indicator/PLUS_DI.htm).  
 ### PLUS_DM - Plus Directional Movement
-```
+NOTE: The ``PLUS_DM`` function has an unstable period.  
+```python
 real = PLUS_DM(high, low, timeperiod=14)
 ```
 
 Learn more about the Plus Directional Movement at [tadoc.org](http://www.tadoc.org/indicator/PLUS_DM.htm).  
 ### PPO - Percentage Price Oscillator
-```
+```python
 real = PPO(close, fastperiod=12, slowperiod=26, matype=0)
 ```
 
 Learn more about the Percentage Price Oscillator at [tadoc.org](http://www.tadoc.org/indicator/PPO.htm).  
 ### ROC - Rate of change : ((price/prevPrice)-1)*100
-```
+```python
 real = ROC(close, timeperiod=10)
 ```
 
 Learn more about the Rate of change : ((price/prevPrice)-1)*100 at [tadoc.org](http://www.tadoc.org/indicator/ROC.htm).  
 ### ROCP - Rate of change Percentage: (price-prevPrice)/prevPrice
-```
+```python
 real = ROCP(close, timeperiod=10)
 ```
 
 Learn more about the Rate of change Percentage: (price-prevPrice)/prevPrice at [tadoc.org](http://www.tadoc.org/indicator/ROCP.htm).  
 ### ROCR - Rate of change ratio: (price/prevPrice)
-```
+```python
 real = ROCR(close, timeperiod=10)
 ```
 
 Learn more about the Rate of change ratio: (price/prevPrice) at [tadoc.org](http://www.tadoc.org/indicator/ROCR.htm).  
 ### ROCR100 - Rate of change ratio 100 scale: (price/prevPrice)*100
-```
+```python
 real = ROCR100(close, timeperiod=10)
 ```
 
 Learn more about the Rate of change ratio 100 scale: (price/prevPrice)*100 at [tadoc.org](http://www.tadoc.org/indicator/ROCR100.htm).  
 ### RSI - Relative Strength Index
-```
+NOTE: The ``RSI`` function has an unstable period.  
+```python
 real = RSI(close, timeperiod=14)
 ```
 
 Learn more about the Relative Strength Index at [tadoc.org](http://www.tadoc.org/indicator/RSI.htm).  
 ### STOCH - Stochastic
-```
+```python
 slowk, slowd = STOCH(high, low, close, fastk_period=5, slowk_period=3, slowk_matype=0, slowd_period=3, slowd_matype=0)
 ```
 
 Learn more about the Stochastic at [tadoc.org](http://www.tadoc.org/indicator/STOCH.htm).  
 ### STOCHF - Stochastic Fast
-```
+```python
 fastk, fastd = STOCHF(high, low, close, fastk_period=5, fastd_period=3, fastd_matype=0)
 ```
 
 Learn more about the Stochastic Fast at [tadoc.org](http://www.tadoc.org/indicator/STOCHF.htm).  
 ### STOCHRSI - Stochastic Relative Strength Index
-```
+NOTE: The ``STOCHRSI`` function has an unstable period.  
+```python
 fastk, fastd = STOCHRSI(close, timeperiod=14, fastk_period=5, fastd_period=3, fastd_matype=0)
 ```
 
 Learn more about the Stochastic Relative Strength Index at [tadoc.org](http://www.tadoc.org/indicator/STOCHRSI.htm).  
 ### TRIX - 1-day Rate-Of-Change (ROC) of a Triple Smooth EMA
-```
+```python
 real = TRIX(close, timeperiod=30)
 ```
 
 Learn more about the 1-day Rate-Of-Change (ROC) of a Triple Smooth EMA at [tadoc.org](http://www.tadoc.org/indicator/TRIX.htm).  
 ### ULTOSC - Ultimate Oscillator
-```
+```python
 real = ULTOSC(high, low, close, timeperiod1=7, timeperiod2=14, timeperiod3=28)
 ```
 
 Learn more about the Ultimate Oscillator at [tadoc.org](http://www.tadoc.org/indicator/ULTOSC.htm).  
 ### WILLR - Williams' %R
-```
+```python
 real = WILLR(high, low, close, timeperiod=14)
 ```
 

--- a/docs/func_groups/overlap_studies.md
+++ b/docs/func_groups/overlap_studies.md
@@ -1,99 +1,104 @@
 # Overlap Studies Functions
 ### BBANDS - Bollinger Bands
-```
+```python
 upperband, middleband, lowerband = BBANDS(close, timeperiod=5, nbdevup=2, nbdevdn=2, matype=0)
 ```
 
 Learn more about the Bollinger Bands at [tadoc.org](http://www.tadoc.org/indicator/BBANDS.htm).  
 ### DEMA - Double Exponential Moving Average
-```
+```python
 real = DEMA(close, timeperiod=30)
 ```
 
 Learn more about the Double Exponential Moving Average at [tadoc.org](http://www.tadoc.org/indicator/DEMA.htm).  
 ### EMA - Exponential Moving Average
-```
+NOTE: The ``EMA`` function has an unstable period.  
+```python
 real = EMA(close, timeperiod=30)
 ```
 
 Learn more about the Exponential Moving Average at [tadoc.org](http://www.tadoc.org/indicator/EMA.htm).  
 ### HT_TRENDLINE - Hilbert Transform - Instantaneous Trendline
-```
+NOTE: The ``HT_TRENDLINE`` function has an unstable period.  
+```python
 real = HT_TRENDLINE(close)
 ```
 
 Learn more about the Hilbert Transform - Instantaneous Trendline at [tadoc.org](http://www.tadoc.org/indicator/HT_TRENDLINE.htm).  
 ### KAMA - Kaufman Adaptive Moving Average
-```
+NOTE: The ``KAMA`` function has an unstable period.  
+```python
 real = KAMA(close, timeperiod=30)
 ```
 
 Learn more about the Kaufman Adaptive Moving Average at [tadoc.org](http://www.tadoc.org/indicator/KAMA.htm).  
 ### MA - Moving average
-```
+```python
 real = MA(close, timeperiod=30, matype=0)
 ```
 
 ### MAMA - MESA Adaptive Moving Average
-```
+NOTE: The ``MAMA`` function has an unstable period.  
+```python
 mama, fama = MAMA(close, fastlimit=0, slowlimit=0)
 ```
 
 Learn more about the MESA Adaptive Moving Average at [tadoc.org](http://www.tadoc.org/indicator/MAMA.htm).  
 ### MAVP - Moving average with variable period
-```
+```python
 real = MAVP(close, periods, minperiod=2, maxperiod=30, matype=0)
 ```
 
 ### MIDPOINT - MidPoint over period
-```
+```python
 real = MIDPOINT(close, timeperiod=14)
 ```
 
 Learn more about the MidPoint over period at [tadoc.org](http://www.tadoc.org/indicator/MIDPOINT.htm).  
 ### MIDPRICE - Midpoint Price over period
-```
+```python
 real = MIDPRICE(high, low, timeperiod=14)
 ```
 
 Learn more about the Midpoint Price over period at [tadoc.org](http://www.tadoc.org/indicator/MIDPRICE.htm).  
 ### SAR - Parabolic SAR
-```
+```python
 real = SAR(high, low, acceleration=0, maximum=0)
 ```
 
 Learn more about the Parabolic SAR at [tadoc.org](http://www.tadoc.org/indicator/SAR.htm).  
 ### SAREXT - Parabolic SAR - Extended
-```
+```python
 real = SAREXT(high, low, startvalue=0, offsetonreverse=0, accelerationinitlong=0, accelerationlong=0, accelerationmaxlong=0, accelerationinitshort=0, accelerationshort=0, accelerationmaxshort=0)
 ```
 
 ### SMA - Simple Moving Average
-```
+```python
 real = SMA(close, timeperiod=30)
 ```
 
 Learn more about the Simple Moving Average at [tadoc.org](http://www.tadoc.org/indicator/SMA.htm).  
 ### T3 - Triple Exponential Moving Average (T3)
-```
+NOTE: The ``T3`` function has an unstable period.  
+```python
 real = T3(close, timeperiod=5, vfactor=0)
 ```
 
 Learn more about the Triple Exponential Moving Average (T3) at [tadoc.org](http://www.tadoc.org/indicator/T3.htm).  
 ### TEMA - Triple Exponential Moving Average
-```
+```python
 real = TEMA(close, timeperiod=30)
 ```
 
 Learn more about the Triple Exponential Moving Average at [tadoc.org](http://www.tadoc.org/indicator/TEMA.htm).  
 ### TRIMA - Triangular Moving Average
-```
+```python
 real = TRIMA(close, timeperiod=30)
 ```
 
 Learn more about the Triangular Moving Average at [tadoc.org](http://www.tadoc.org/indicator/TRIMA.htm).  
 ### WMA - Weighted Moving Average
-```
+```python
 real = WMA(close, timeperiod=30)
 ```
 

--- a/docs/func_groups/pattern_recognition.md
+++ b/docs/func_groups/pattern_recognition.md
@@ -1,306 +1,306 @@
 # Pattern Recognition Functions
 ### CDL2CROWS - Two Crows
-```
+```python
 integer = CDL2CROWS(open, high, low, close)
 ```
 
 ### CDL3BLACKCROWS - Three Black Crows
-```
+```python
 integer = CDL3BLACKCROWS(open, high, low, close)
 ```
 
 ### CDL3INSIDE - Three Inside Up/Down
-```
+```python
 integer = CDL3INSIDE(open, high, low, close)
 ```
 
 ### CDL3LINESTRIKE - Three-Line Strike 
-```
+```python
 integer = CDL3LINESTRIKE(open, high, low, close)
 ```
 
 ### CDL3OUTSIDE - Three Outside Up/Down
-```
+```python
 integer = CDL3OUTSIDE(open, high, low, close)
 ```
 
 ### CDL3STARSINSOUTH - Three Stars In The South
-```
+```python
 integer = CDL3STARSINSOUTH(open, high, low, close)
 ```
 
 ### CDL3WHITESOLDIERS - Three Advancing White Soldiers
-```
+```python
 integer = CDL3WHITESOLDIERS(open, high, low, close)
 ```
 
 ### CDLABANDONEDBABY - Abandoned Baby
-```
+```python
 integer = CDLABANDONEDBABY(open, high, low, close, penetration=0)
 ```
 
 ### CDLADVANCEBLOCK - Advance Block
-```
+```python
 integer = CDLADVANCEBLOCK(open, high, low, close)
 ```
 
 ### CDLBELTHOLD - Belt-hold
-```
+```python
 integer = CDLBELTHOLD(open, high, low, close)
 ```
 
 ### CDLBREAKAWAY - Breakaway
-```
+```python
 integer = CDLBREAKAWAY(open, high, low, close)
 ```
 
 ### CDLCLOSINGMARUBOZU - Closing Marubozu
-```
+```python
 integer = CDLCLOSINGMARUBOZU(open, high, low, close)
 ```
 
 ### CDLCONCEALBABYSWALL - Concealing Baby Swallow
-```
+```python
 integer = CDLCONCEALBABYSWALL(open, high, low, close)
 ```
 
 ### CDLCOUNTERATTACK - Counterattack
-```
+```python
 integer = CDLCOUNTERATTACK(open, high, low, close)
 ```
 
 ### CDLDARKCLOUDCOVER - Dark Cloud Cover
-```
+```python
 integer = CDLDARKCLOUDCOVER(open, high, low, close, penetration=0)
 ```
 
 ### CDLDOJI - Doji
-```
+```python
 integer = CDLDOJI(open, high, low, close)
 ```
 
 ### CDLDOJISTAR - Doji Star
-```
+```python
 integer = CDLDOJISTAR(open, high, low, close)
 ```
 
 ### CDLDRAGONFLYDOJI - Dragonfly Doji
-```
+```python
 integer = CDLDRAGONFLYDOJI(open, high, low, close)
 ```
 
 ### CDLENGULFING - Engulfing Pattern
-```
+```python
 integer = CDLENGULFING(open, high, low, close)
 ```
 
 ### CDLEVENINGDOJISTAR - Evening Doji Star
-```
+```python
 integer = CDLEVENINGDOJISTAR(open, high, low, close, penetration=0)
 ```
 
 ### CDLEVENINGSTAR - Evening Star
-```
+```python
 integer = CDLEVENINGSTAR(open, high, low, close, penetration=0)
 ```
 
 ### CDLGAPSIDESIDEWHITE - Up/Down-gap side-by-side white lines
-```
+```python
 integer = CDLGAPSIDESIDEWHITE(open, high, low, close)
 ```
 
 ### CDLGRAVESTONEDOJI - Gravestone Doji
-```
+```python
 integer = CDLGRAVESTONEDOJI(open, high, low, close)
 ```
 
 ### CDLHAMMER - Hammer
-```
+```python
 integer = CDLHAMMER(open, high, low, close)
 ```
 
 ### CDLHANGINGMAN - Hanging Man
-```
+```python
 integer = CDLHANGINGMAN(open, high, low, close)
 ```
 
 ### CDLHARAMI - Harami Pattern
-```
+```python
 integer = CDLHARAMI(open, high, low, close)
 ```
 
 ### CDLHARAMICROSS - Harami Cross Pattern
-```
+```python
 integer = CDLHARAMICROSS(open, high, low, close)
 ```
 
 ### CDLHIGHWAVE - High-Wave Candle
-```
+```python
 integer = CDLHIGHWAVE(open, high, low, close)
 ```
 
 ### CDLHIKKAKE - Hikkake Pattern
-```
+```python
 integer = CDLHIKKAKE(open, high, low, close)
 ```
 
 ### CDLHIKKAKEMOD - Modified Hikkake Pattern
-```
+```python
 integer = CDLHIKKAKEMOD(open, high, low, close)
 ```
 
 ### CDLHOMINGPIGEON - Homing Pigeon
-```
+```python
 integer = CDLHOMINGPIGEON(open, high, low, close)
 ```
 
 ### CDLIDENTICAL3CROWS - Identical Three Crows
-```
+```python
 integer = CDLIDENTICAL3CROWS(open, high, low, close)
 ```
 
 ### CDLINNECK - In-Neck Pattern
-```
+```python
 integer = CDLINNECK(open, high, low, close)
 ```
 
 ### CDLINVERTEDHAMMER - Inverted Hammer
-```
+```python
 integer = CDLINVERTEDHAMMER(open, high, low, close)
 ```
 
 ### CDLKICKING - Kicking
-```
+```python
 integer = CDLKICKING(open, high, low, close)
 ```
 
 ### CDLKICKINGBYLENGTH - Kicking - bull/bear determined by the longer marubozu
-```
+```python
 integer = CDLKICKINGBYLENGTH(open, high, low, close)
 ```
 
 ### CDLLADDERBOTTOM - Ladder Bottom
-```
+```python
 integer = CDLLADDERBOTTOM(open, high, low, close)
 ```
 
 ### CDLLONGLEGGEDDOJI - Long Legged Doji
-```
+```python
 integer = CDLLONGLEGGEDDOJI(open, high, low, close)
 ```
 
 ### CDLLONGLINE - Long Line Candle
-```
+```python
 integer = CDLLONGLINE(open, high, low, close)
 ```
 
 ### CDLMARUBOZU - Marubozu
-```
+```python
 integer = CDLMARUBOZU(open, high, low, close)
 ```
 
 ### CDLMATCHINGLOW - Matching Low
-```
+```python
 integer = CDLMATCHINGLOW(open, high, low, close)
 ```
 
 ### CDLMATHOLD - Mat Hold
-```
+```python
 integer = CDLMATHOLD(open, high, low, close, penetration=0)
 ```
 
 ### CDLMORNINGDOJISTAR - Morning Doji Star
-```
+```python
 integer = CDLMORNINGDOJISTAR(open, high, low, close, penetration=0)
 ```
 
 ### CDLMORNINGSTAR - Morning Star
-```
+```python
 integer = CDLMORNINGSTAR(open, high, low, close, penetration=0)
 ```
 
 ### CDLONNECK - On-Neck Pattern
-```
+```python
 integer = CDLONNECK(open, high, low, close)
 ```
 
 ### CDLPIERCING - Piercing Pattern
-```
+```python
 integer = CDLPIERCING(open, high, low, close)
 ```
 
 ### CDLRICKSHAWMAN - Rickshaw Man
-```
+```python
 integer = CDLRICKSHAWMAN(open, high, low, close)
 ```
 
 ### CDLRISEFALL3METHODS - Rising/Falling Three Methods
-```
+```python
 integer = CDLRISEFALL3METHODS(open, high, low, close)
 ```
 
 ### CDLSEPARATINGLINES - Separating Lines
-```
+```python
 integer = CDLSEPARATINGLINES(open, high, low, close)
 ```
 
 ### CDLSHOOTINGSTAR - Shooting Star
-```
+```python
 integer = CDLSHOOTINGSTAR(open, high, low, close)
 ```
 
 ### CDLSHORTLINE - Short Line Candle
-```
+```python
 integer = CDLSHORTLINE(open, high, low, close)
 ```
 
 ### CDLSPINNINGTOP - Spinning Top
-```
+```python
 integer = CDLSPINNINGTOP(open, high, low, close)
 ```
 
 ### CDLSTALLEDPATTERN - Stalled Pattern
-```
+```python
 integer = CDLSTALLEDPATTERN(open, high, low, close)
 ```
 
 ### CDLSTICKSANDWICH - Stick Sandwich
-```
+```python
 integer = CDLSTICKSANDWICH(open, high, low, close)
 ```
 
 ### CDLTAKURI - Takuri (Dragonfly Doji with very long lower shadow)
-```
+```python
 integer = CDLTAKURI(open, high, low, close)
 ```
 
 ### CDLTASUKIGAP - Tasuki Gap
-```
+```python
 integer = CDLTASUKIGAP(open, high, low, close)
 ```
 
 ### CDLTHRUSTING - Thrusting Pattern
-```
+```python
 integer = CDLTHRUSTING(open, high, low, close)
 ```
 
 ### CDLTRISTAR - Tristar Pattern
-```
+```python
 integer = CDLTRISTAR(open, high, low, close)
 ```
 
 ### CDLUNIQUE3RIVER - Unique 3 River
-```
+```python
 integer = CDLUNIQUE3RIVER(open, high, low, close)
 ```
 
 ### CDLUPSIDEGAP2CROWS - Upside Gap Two Crows
-```
+```python
 integer = CDLUPSIDEGAP2CROWS(open, high, low, close)
 ```
 
 ### CDLXSIDEGAP3METHODS - Upside/Downside Gap Three Methods
-```
+```python
 integer = CDLXSIDEGAP3METHODS(open, high, low, close)
 ```
 

--- a/docs/func_groups/price_transform.md
+++ b/docs/func_groups/price_transform.md
@@ -1,24 +1,24 @@
 # Price Transform Functions
 ### AVGPRICE - Average Price
-```
+```python
 real = AVGPRICE(open, high, low, close)
 ```
 
 Learn more about the Average Price at [tadoc.org](http://www.tadoc.org/indicator/AVGPRICE.htm).  
 ### MEDPRICE - Median Price
-```
+```python
 real = MEDPRICE(high, low)
 ```
 
 Learn more about the Median Price at [tadoc.org](http://www.tadoc.org/indicator/MEDPRICE.htm).  
 ### TYPPRICE - Typical Price
-```
+```python
 real = TYPPRICE(high, low, close)
 ```
 
 Learn more about the Typical Price at [tadoc.org](http://www.tadoc.org/indicator/TYPPRICE.htm).  
 ### WCLPRICE - Weighted Close Price
-```
+```python
 real = WCLPRICE(high, low, close)
 ```
 

--- a/docs/func_groups/statistic_functions.md
+++ b/docs/func_groups/statistic_functions.md
@@ -1,54 +1,54 @@
 # Statistic Functions
 ### BETA - Beta
-```
+```python
 real = BETA(high, low, timeperiod=5)
 ```
 
 Learn more about the Beta at [tadoc.org](http://www.tadoc.org/indicator/BETA.htm).  
 ### CORREL - Pearson's Correlation Coefficient (r)
-```
+```python
 real = CORREL(high, low, timeperiod=30)
 ```
 
 Learn more about the Pearson's Correlation Coefficient (r) at [tadoc.org](http://www.tadoc.org/indicator/CORREL.htm).  
 ### LINEARREG - Linear Regression
-```
+```python
 real = LINEARREG(close, timeperiod=14)
 ```
 
 Learn more about the Linear Regression at [tadoc.org](http://www.tadoc.org/indicator/LINEARREG.htm).  
 ### LINEARREG_ANGLE - Linear Regression Angle
-```
+```python
 real = LINEARREG_ANGLE(close, timeperiod=14)
 ```
 
 Learn more about the Linear Regression Angle at [tadoc.org](http://www.tadoc.org/indicator/LINEARREG_ANGLE.htm).  
 ### LINEARREG_INTERCEPT - Linear Regression Intercept
-```
+```python
 real = LINEARREG_INTERCEPT(close, timeperiod=14)
 ```
 
 Learn more about the Linear Regression Intercept at [tadoc.org](http://www.tadoc.org/indicator/LINEARREG_INTERCEPT.htm).  
 ### LINEARREG_SLOPE - Linear Regression Slope
-```
+```python
 real = LINEARREG_SLOPE(close, timeperiod=14)
 ```
 
 Learn more about the Linear Regression Slope at [tadoc.org](http://www.tadoc.org/indicator/LINEARREG_SLOPE.htm).  
 ### STDDEV - Standard Deviation
-```
+```python
 real = STDDEV(close, timeperiod=5, nbdev=1)
 ```
 
 Learn more about the Standard Deviation at [tadoc.org](http://www.tadoc.org/indicator/STDDEV.htm).  
 ### TSF - Time Series Forecast
-```
+```python
 real = TSF(close, timeperiod=14)
 ```
 
 Learn more about the Time Series Forecast at [tadoc.org](http://www.tadoc.org/indicator/TSF.htm).  
 ### VAR - Variance
-```
+```python
 real = VAR(close, timeperiod=5, nbdev=1)
 ```
 

--- a/docs/func_groups/volatility_indicators.md
+++ b/docs/func_groups/volatility_indicators.md
@@ -1,18 +1,20 @@
 # Volatility Indicator Functions
 ### ATR - Average True Range
-```
+NOTE: The ``ATR`` function has an unstable period.  
+```python
 real = ATR(high, low, close, timeperiod=14)
 ```
 
 Learn more about the Average True Range at [tadoc.org](http://www.tadoc.org/indicator/ATR.htm).  
 ### NATR - Normalized Average True Range
-```
+NOTE: The ``NATR`` function has an unstable period.  
+```python
 real = NATR(high, low, close, timeperiod=14)
 ```
 
 Learn more about the Normalized Average True Range at [tadoc.org](http://www.tadoc.org/indicator/NATR.htm).  
 ### TRANGE - True Range
-```
+```python
 real = TRANGE(high, low, close)
 ```
 

--- a/docs/func_groups/volume_indicators.md
+++ b/docs/func_groups/volume_indicators.md
@@ -1,18 +1,18 @@
 # Volume Indicator Functions
 ### AD - Chaikin A/D Line
-```
+```python
 real = AD(high, low, close, volume)
 ```
 
 Learn more about the Chaikin A/D Line at [tadoc.org](http://www.tadoc.org/indicator/AD.htm).  
 ### ADOSC - Chaikin A/D Oscillator
-```
+```python
 real = ADOSC(high, low, close, volume, fastperiod=3, slowperiod=10)
 ```
 
 Learn more about the Chaikin A/D Oscillator at [tadoc.org](http://www.tadoc.org/indicator/ADOSC.htm).  
 ### OBV - On Balance Volume
-```
+```python
 real = OBV(close, volume)
 ```
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,5 @@
+numpy==1.11.1
+beautifulsoup4==4.5.1
+mistune==0.7.3
+Cython==0.24.1
+Pygments==2.1.3

--- a/talib/__init__.py
+++ b/talib/__init__.py
@@ -3,6 +3,7 @@ import atexit
 
 from . import common
 from . import abstract
+from . import stream
 from .common import MA_Type, __ta_version__
 from .common import _ta_set_unstable_period as set_unstable_period
 from .common import _ta_get_unstable_period as get_unstable_period


### PR DESCRIPTION
Not a whole lot of changes here, despite the size of the diff. Mostly I did some cleanups to the markdown_to_html code:  
* I switched it to using the ``mistune`` library for the markdown conversion, in conjunction with ``pygments`` for code highlighting. 
* A bugfix for the OBV function's generated documentation (it wasn't correctly outputting that one function's parameters)
* The script now accepts an optional positional argument to specify a path for where to dump the generated html files (useful for dumping to a second directory checked out to the gh-pages branch)
