### PR TITLE
let setup.py automatically handle rpath

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,15 +80,26 @@ cmdclass = {}
 if has_cython:
     cmdclass['build_ext'] = build_ext
 
+runtime_lib_dirs =  os.environ['TA_LIBRARY_PATH']
+if runtime_lib_dirs:
+    runtime_lib_dirs = runtime_lib_dirs.split(os.pathsep)
+else:
+    runtime_lib_dirs = []
+
+# warnings.warn('runtime_lib_dirs = {}'.format(runtime_lib_dirs))
+# warnings.warn('lib_talib_dirs = {}'.format(lib_talib_dirs))
+
 ext_modules = [
     Extension(
         'talib._ta_lib',
         ['talib/_ta_lib.pyx' if has_cython else 'talib/_ta_lib.c'],
         include_dirs=include_dirs,
         library_dirs=lib_talib_dirs,
-        libraries=[lib_talib_name]
+        libraries=[lib_talib_name],
+        runtime_library_dirs=runtime_lib_dirs
     )
 ]
+
 
 setup(
     name = 'TA-Lib',


### PR DESCRIPTION
When user install ta-lib in custom location like `~/opt/ta-lib`, we can set `TA_LIBRARY_PATH` and `TA_INCLUDE_PATH` to let the setup.py set `-L` and `-I` options for compiler. One would expect our setup.py can automatically handle the runtime lib search path also, since he/she already set the environment parameter. However, it does not do this. Without `--rpath`, it will give out error that it cannot find the `libta_lib.so.0` when import talib. Right now, we have to use `.pydistutils.cfg`'s build_ext section to set rpath, which is very annoying and surprising, since no error/warning has been giving during installation.
Thus I added runtime_lib_dirs in Extension. This modification can let setup.py automatically handle rpath instead of passing build_ext arguments during installing.