### PR TITLE
Add pandas.Series support

### DIFF
--- a/talib/__init__.py
+++ b/talib/__init__.py
@@ -1,5 +1,44 @@
 
 import atexit
+from itertools import chain
+from functools import wraps
+
+# If pandas is available, wrap talib functions so that they support
+# pandas.Series input
+try:
+    from pandas import Series as _pd_Series
+except ImportError:
+    # pandas not available, nothing to wrap
+    _pandas_wrapper = lambda x: x
+else:
+    def _pandas_wrapper(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            try:
+                # Get the index of the first Series object, if any
+                index = next(arg.index
+                             for arg in chain(args, kwargs.values())
+                             if isinstance(arg, _pd_Series))
+            except StopIteration:
+                # No pandas.Series passed in; short-circuit
+                return func(*args, **kwargs)
+
+            # Use Series' float64 values if pandas, else use values as passed
+            args = [arg.values.astype(float) if isinstance(arg, _pd_Series) else arg
+                    for arg in args]
+            kwargs = {k: v.values.astype(float) if isinstance(v, _pd_Series) else v
+                      for k, v in kwargs.items()}
+
+            result = func(*args, **kwargs)
+
+            # Series was passed in, Series gets out; re-apply index
+            if isinstance(result, tuple):
+                # Handle multi-array results such as BBANDS
+                return tuple(_pd_Series(arr, index=index)
+                             for arr in result)
+            return _pd_Series(result, index=index)
+
+        return wrapper
 
 from ._ta_lib import (
     _ta_initialize, _ta_shutdown, MA_Type, __ta_version__,
@@ -10,7 +49,9 @@ from ._ta_lib import (
 
 func = __import__("_ta_lib", globals(), locals(), __TA_FUNCTION_NAMES__, level=1)
 for func_name in __TA_FUNCTION_NAMES__:
-    globals()[func_name] = getattr(func, func_name)
+    wrapped_func = _pandas_wrapper(getattr(func, func_name))
+    setattr(func, func_name, wrapped_func)
+    globals()[func_name] = wrapped_func
 
 __version__ = '0.4.10'
 

--- a/talib/test_abstract.py
+++ b/talib/test_abstract.py
@@ -41,6 +41,29 @@ def test_pandas():
     assert_np_arrays_equal(expected, output)
 
 
+def test_pandas_series():
+    import pandas
+    input_df = pandas.DataFrame(ford_2012)
+    output = talib.SMA(input_df['close'], 10)
+    expected = pandas.Series(func.SMA(ford_2012['close'], 10),
+                             index=input_df.index)
+    pandas.util.testing.assert_series_equal(output, expected)
+
+    # Test kwargs
+    output = talib.SMA(real=input_df['close'], timeperiod=10)
+    pandas.util.testing.assert_series_equal(output, expected)
+
+    # Test talib.func API
+    output = func.SMA(input_df['close'], timeperiod=10)
+    pandas.util.testing.assert_series_equal(output, expected)
+
+    # Test multiple outputs such as from BBANDS
+    _, output, _ = talib.BBANDS(input_df['close'], 10)
+    expected = pandas.Series(func.BBANDS(ford_2012['close'], 10)[1],
+                             index=input_df.index)
+    pandas.util.testing.assert_series_equal(output, expected)
+
+
 def test_SMA():
     expected = func.SMA(ford_2012['close'], 10)
     assert_np_arrays_equal(expected, abstract.Function('sma', ford_2012, 10).outputs)


### PR DESCRIPTION
Fixes https://github.com/mrjbq7/ta-lib/issues/56, closes https://github.com/mrjbq7/ta-lib/pull/122

Another take at pd.Series support: a simple wrapper.

Allows for notebook code like:
![screenshot_2017-07-28_20-12-47](https://user-images.githubusercontent.com/684364/28731203-4cd71910-73d3-11e7-9588-357e4427c2e9.png)

~~Currently, only top-level `talib` namespace is patched.~~ Is this the preferred API (e.g. `import talib as ta; ta.SMA(...)`?