### PR TITLE
fix subsequent calls to abstract TA functions using DataFrame as input arrays

### DIFF
--- a/talib/_abstract.pxi
+++ b/talib/_abstract.pxi
@@ -377,7 +377,8 @@ class Function(object):
                         ', '.join(input_price_series_names))
                     raise TypeError(msg)
 
-        if isinstance(self.__input_arrays, __PANDAS_DATAFRAME):
+        if __PANDAS_DATAFRAME is not None \
+                and isinstance(self.__input_arrays, __PANDAS_DATAFRAME):
             no_existing_input_arrays = self.__input_arrays.empty
         else:
             no_existing_input_arrays = not bool(self.__input_arrays)

--- a/talib/_abstract.pxi
+++ b/talib/_abstract.pxi
@@ -377,10 +377,15 @@ class Function(object):
                         ', '.join(input_price_series_names))
                     raise TypeError(msg)
 
+        if isinstance(self.__input_arrays, __PANDAS_DATAFRAME):
+            no_existing_input_arrays = self.__input_arrays.empty
+        else:
+            no_existing_input_arrays = not bool(self.__input_arrays)
+
         if len(input_arrays) == len(input_price_series_names):
             self.set_input_arrays(input_arrays)
             args = args[len(input_arrays):]
-        elif len(input_arrays) or (not self.__input_arrays and (
+        elif len(input_arrays) or (no_existing_input_arrays and (
                 not len(args) or not isinstance(args[0], __INPUT_ARRAYS_TYPES))):
             msg = 'Not enough price arguments: expected %d (%s)' % (
                 len(input_price_series_names),


### PR DESCRIPTION
Attempting to run the following code:

```python
import talib.abstract as ta
import pandas as pd
import numpy as np


inputs = {
    'open': np.random.random(100),
    'high': np.random.random(100),
    'low': np.random.random(100),
    'close': np.random.random(100),
    'volume': np.random.random(100)
}
dataframe = pd.DataFrame(inputs)

dataframe['minusdi'] = ta.MINUS_DI(dataframe)
dataframe['minusdi_25'] = ta.MINUS_DI(dataframe, timeperiod=25)
```

Raises the following exception:

```
~/dev/ta-lib/talib/_abstract.pxi in talib._ta_lib.Function.__call__()
    381             self.set_input_arrays(input_arrays)
    382             args = args[len(input_arrays):]
--> 383         elif len(input_arrays) or (not self.__input_arrays and (
    384                 not len(args) or not isinstance(args[0], __INPUT_ARRAYS_TYPES))):
    385             msg = 'Not enough price arguments: expected %d (%s)' % (

~/.virtualenvs/talib/lib/python3.7/site-packages/pandas/core/generic.py in __nonzero__(self)
   1476         raise ValueError("The truth value of a {0} is ambiguous. "
   1477                          "Use a.empty, a.bool(), a.item(), a.any() or a.all()."
-> 1478                          .format(self.__class__.__name__))
   1479 
   1480     __bool__ = __nonzero__

ValueError: The truth value of a DataFrame is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all().
```

This PR fixes it. I didn't update `talib/_ta_lib.c` however.