### PR TITLE
do not cache input price series names in abstract Function.__call__

### DIFF
--- a/talib/_abstract.pxi
+++ b/talib/_abstract.pxi
@@ -359,6 +359,8 @@ class Function(object):
         # do not cache ta-func parameters passed to __call__
         opt_input_values = [(param_name, self.__opt_inputs[param_name]['value'])
                             for param_name in self.__opt_inputs.keys()]
+        price_series_name_values = [(n, self.__input_names[n]['price_series'])
+                                    for n in self.__input_names]
 
         # allow calling with same signature as talib.func module functions
         args = list(args)
@@ -399,6 +401,12 @@ class Function(object):
         # restore opt_input values to as they were before this call
         for param_name, value in opt_input_values:
             self.__opt_inputs[param_name]['value'] = value
+        self.__info['parameters'] = self.parameters
+
+        # restore input names values to as they were before this call
+        for input_name, value in price_series_name_values:
+            self.__input_names[input_name]['price_series'] = value
+            self.__info['input_names'][input_name] = value
 
         return self.outputs
 

--- a/talib/test_abstract.py
+++ b/talib/test_abstract.py
@@ -297,6 +297,10 @@ def test_parameter_type_checking():
 def test_call_doesnt_cache_parameters():
     sma = abstract.Function('SMA', timeperiod=10)
 
+    expected = func.SMA(ford_2012['open'], 20)
+    output = sma(ford_2012, timeperiod=20, price='open')
+    assert_np_arrays_equal(expected, output)
+
     expected = func.SMA(ford_2012['close'], 20)
     output = sma(ford_2012, timeperiod=20)
     assert_np_arrays_equal(expected, output)


### PR DESCRIPTION
Another bugfix for https://github.com/mrjbq7/ta-lib/issues/306

Once again I didn't include `talib/_ta_lib.c`, generating it on Linux seems to strip out the Windows-specific stuffs :/