### PR TITLE
Fixing links

### DIFF
--- a/docs/funcs.md
+++ b/docs/funcs.md
@@ -1,17 +1,17 @@
 # All Supported Indicators and Functions
 
-* [Overlap Studies](func_groups/overlap_studies.html)
-* [Momentum Indicators](func_groups/momentum_indicators.html)
-* [Volume Indicators](func_groups/volume_indicators.html)
-* [Volatility Indicators](func_groups/volatility_indicators.html)
-* [Price Transform](func_groups/price_transform.html)
-* [Cycle Indicators](func_groups/cycle_indicators.html)
-* [Pattern Recognition](func_groups/pattern_recognition.html)
-* [Statistic Functions](func_groups/statistic_functions.html)
-* [Math Transform](func_groups/math_transform.html)
-* [Math Operators](func_groups/math_operators.html)
+* [Overlap Studies](func_groups/overlap_studies.md)
+* [Momentum Indicators](func_groups/momentum_indicators.md)
+* [Volume Indicators](func_groups/volume_indicators.md)
+* [Volatility Indicators](func_groups/volatility_indicators.md)
+* [Price Transform](func_groups/price_transform.md)
+* [Cycle Indicators](func_groups/cycle_indicators.md)
+* [Pattern Recognition](func_groups/pattern_recognition.md)
+* [Statistic Functions](func_groups/statistic_functions.md)
+* [Math Transform](func_groups/math_transform.md)
+* [Math Operators](func_groups/math_operators.md)
 
-#### [Overlap Studies](func_groups/overlap_studies.html)
+#### [Overlap Studies](func_groups/overlap_studies.md)
 
 ```
 BBANDS               Bollinger Bands
@@ -33,7 +33,7 @@ TRIMA                Triangular Moving Average
 WMA                  Weighted Moving Average
 ```
 
-#### [Momentum Indicators](func_groups/momentum_indicators.html)
+#### [Momentum Indicators](func_groups/momentum_indicators.md)
 
 ```
 ADX                  Average Directional Movement Index
@@ -68,7 +68,7 @@ ULTOSC               Ultimate Oscillator
 WILLR                Williams' %R
 ```
 
-#### [Volume Indicators](func_groups/volume_indicators.html)
+#### [Volume Indicators](func_groups/volume_indicators.md)
 
 ```
 AD                   Chaikin A/D Line
@@ -76,7 +76,7 @@ ADOSC                Chaikin A/D Oscillator
 OBV                  On Balance Volume
 ```
 
-#### [Cycle Indicators](func_groups/cycle_indicators.html)
+#### [Cycle Indicators](func_groups/cycle_indicators.md)
 
 ```
 HT_DCPERIOD          Hilbert Transform - Dominant Cycle Period
@@ -86,7 +86,7 @@ HT_SINE              Hilbert Transform - SineWave
 HT_TRENDMODE         Hilbert Transform - Trend vs Cycle Mode
 ```
 
-#### [Price Transform](func_groups/price_transform.html)
+#### [Price Transform](func_groups/price_transform.md)
 
 ```
 AVGPRICE             Average Price
@@ -95,7 +95,7 @@ TYPPRICE             Typical Price
 WCLPRICE             Weighted Close Price
 ```
 
-#### [Volatility Indicators](func_groups/volatility_indicators.html)
+#### [Volatility Indicators](func_groups/volatility_indicators.md)
 
 ```
 ATR                  Average True Range
@@ -103,7 +103,7 @@ NATR                 Normalized Average True Range
 TRANGE               True Range
 ```
 
-#### [Pattern Recognition](func_groups/pattern_recognition.html)
+#### [Pattern Recognition](func_groups/pattern_recognition.md)
 
 ```
 CDL2CROWS            Two Crows
@@ -169,7 +169,7 @@ CDLUPSIDEGAP2CROWS   Upside Gap Two Crows
 CDLXSIDEGAP3METHODS  Upside/Downside Gap Three Methods
 ```
 
-#### [Statistic Functions](func_groups/statistic_functions.html)
+#### [Statistic Functions](func_groups/statistic_functions.md)
 
 ```
 BETA                 Beta
@@ -183,7 +183,7 @@ TSF                  Time Series Forecast
 VAR                  Variance
 ```
 
-#### [Math Transform](func_groups/math_transform.html)
+#### [Math Transform](func_groups/math_transform.md)
 
 ```
 ACOS                 Vector Trigonometric ACos
@@ -203,7 +203,7 @@ TAN                  Vector Trigonometric Tan
 TANH                 Vector Trigonometric Tanh
 ```
 
-#### [Math Operators](func_groups/math_operators.html)
+#### [Math Operators](func_groups/math_operators.md)
 
 ```
 ADD                  Vector Arithmetic Add
@@ -219,4 +219,4 @@ SUB                  Vector Arithmetic Substraction
 SUM                  Summation
 ```
 
-[Documentation Index](doc_index.html)
+[Documentation Index](doc_index.md)


### PR DESCRIPTION
Seems docs were pointing out to unexisting html files, leading to interrupted flow for users and contributors at GitHub. I'm proposing changes to the links into the markdown files so the documentation flow can be followed