### PR TITLE
use multi-stage build to minimize size of Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,52 @@
 # Dockerfile for TA-Lib. To build:
 #
-#    docker build --rm -t talib -f Dockerfile .
+#    docker build --rm -t talib .
 #
 # To run:
 #
 #    docker run --rm -it talib bash
 #
-FROM python:3.6
 
+ARG PYTHON_VERSION="3.7"
+
+FROM python:$PYTHON_VERSION as builder
+
+ENV TA_PREFIX="/opt/ta-lib-core"
+ENV TA_LIBRARY_PATH="$TA_PREFIX/lib" \
+    TA_INCLUDE_PATH="$TA_PREFIX/include"
+
+WORKDIR /src/ta-lib-core
 RUN apt-get update && apt-get install -y \
-    gfortran \
-    libfreetype6-dev \
-    libhdf5-dev \
-    liblapack-dev \
-    libopenblas-dev \
-    libpng-dev \
-  && rm -rf /var/lib/apt/lists/* \
-  && curl -L http://prdownloads.sourceforge.net/ta-lib/ta-lib-0.4.0-src.tar.gz \
-  | tar xvz \
-  && cd /ta-lib \
-  && ./configure --prefix=/usr \
-  && make \
-  && make install \
-  && pip install --upgrade pip
+        gfortran \
+        libfreetype6-dev \
+        libhdf5-dev \
+        liblapack-dev \
+        libopenblas-dev \
+        libpng-dev \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -fsSL http://prdownloads.sourceforge.net/ta-lib/ta-lib-0.4.0-src.tar.gz \
+    | tar xvz --strip-components 1 \
+    && ./configure --prefix="$TA_PREFIX" \
+    && make \
+    && make install
 
-WORKDIR /TA-Lib
+WORKDIR /src/ta-lib-python
 COPY . .
+RUN python -m pip install -e . \
+    && python -c 'import numpy, talib; close = numpy.random.random(100); output = talib.SMA(close); print(output)' \
+    && python -m pip wheel --wheel-dir wheels .
 
-RUN python setup.py egg_info \
-  && python setup.py --help \
-  && pip install -e . \
-  && pip -V \
-  && pip freeze \
-  && pip show numpy cython TA_Lib \
-  && python -c 'import numpy; import talib; close = numpy.random.random(100); output = talib.SMA(close); print(output)' \
-  && pip install -r requirements_dev.txt \
-  && pip install -r requirements_test.txt \
-  && nosetests -w .
+ARG RUN_TESTS="1"
+RUN if [ "$RUN_TESTS" -ne "0" ]; then \
+        python -m pip install -r requirements_test.txt \
+        && nosetests -w . ; \
+    else \
+        echo "Skipping tests\n" ; \
+    fi
+
+# Build final image.
+FROM python:$PYTHON_VERSION-slim
+COPY --from=builder /src/ta-lib-python/wheels /opt/ta-lib-python/wheels
+COPY --from=builder /opt/ta-lib-core /opt/ta-lib-core
+RUN python -m pip install --no-cache-dir /opt/ta-lib-python/wheels/*.whl \
+    && python -c 'import numpy, talib; close = numpy.random.random(100); output = talib.SMA(close); print(output)'


### PR DESCRIPTION
The changes in this commit reduce the Docker image size from >1 GB to 205 MB. Docker multi-stage builds were used to achieve this. In the first stage, the core ta-lib library is compiled, and the Python ta-lib package is installed. Then, in the second stage, the compiled core ta-lib library and the Python wheel files are copied over and installed. The second stage also uses the `python:VERSION-slim` Docker image, which is much smaller than the `python:VERSION` image, because it does not include any compilers or other software not necessary at runtime.

The build and run procedure is unchanged. Use `docker build --tag ta-lib .` to build and `docker run --rm -it ta-lib bash` to run.

Another change introduced by the commit is the option of skipping testing during image building. By default, testing is not skipped, but it can be skipped with `docker build --tag ts-lib --build-arg RUN_TESTS=0 .`.

I uploaded a built image to https://hub.docker.com/r/kaczmarj/ta-lib: `docker pull kaczmarj/ta-lib`