### PR TITLE
Additional fixes related to python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,12 @@
 ---
 language: python
 python:
-  - "2.7"
-  - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"
   - "3.9"
 os: linux
-dist: xenial
+dist: bionic
 env:
   global:
     - DEPS_DIR=$HOME/dependencies

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
 -r requirements.txt
-beautifulsoup4==4.7.1
+beautifulsoup4==4.9.3
 mistune==0.8.4
-Pygments==2.3.1
+Pygments==2.7.2

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,3 @@
 -r requirements.txt
-pandas==0.24.2
+pandas==1.1.4
 nose==1.3.7


### PR DESCRIPTION
Remove 2.7 and 3.5 due to end of life errors from Travis and updated the dist.
Also updated the other requirements to fix: "Building wheel for pandas (setup.py) ... error" in the travis 3.9 build.