### PR TITLE
Use TA_INCLUDE_PATH and TA_LIBRARY_PATH on win32

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,8 +56,8 @@ for prefix in ['darwin', 'linux', 'bsd', 'sunos']:
 if sys.platform == "win32":
     platform_supported = True
     lib_talib_name = 'ta_libc_cdr'
-    include_dirs = [r"c:\ta-lib\c\include"]
-    lib_talib_dirs = [r"c:\ta-lib\c\lib"]
+    include_dirs = [os.environ["TA_INCLUDE_PATH"]] if 'TA_INCLUDE_PATH' in os.environ else [r"c:\ta-lib\c\include"]
+    lib_talib_dirs = [os.environ["TA_LIBRARY_PATH"]] if 'TA_LIBRARY_PATH' in os.environ else [r"c:\ta-lib\c\lib"]
 
 if not platform_supported:
     raise NotImplementedError(sys.platform)


### PR DESCRIPTION
This is a fix for issue #482 . The update code utilizes the `TA_INCLUDE_PATH` and `TA_LIBRARY_PATH` environment variables for win32 install if they have been defined.