### PR TITLE
 big mistake reversed high and low bands of bollinger

### DIFF
--- a/docs/func.md
+++ b/docs/func.md
@@ -28,7 +28,7 @@ Calculating bollinger bands, with triple exponential moving average:
 ```python
 from talib import MA_Type
 
-upper, middle, lower = talib.BBANDS(close, matype=MA_Type.T3)
+lower, middle, upper = talib.BBANDS(close, matype=MA_Type.T3)
 ```
 
 Calculating momentum of the close prices, with a time period of 5:


### PR DESCRIPTION
 ```Python
df['bbl'], df['bbm'], df['bbh'] = tal.BBANDS(df['real'].values, timeperiod=period, nbdevup=2.0)
```
```Bash
0.7621999035621772
1.4082029042146873
2.0542059048671977
```