### PR TITLE
Support ta_func.h with TA_LIB_API declarations

### DIFF
--- a/tools/generate_func.py
+++ b/tools/generate_func.py
@@ -26,6 +26,8 @@ if not header_found:
 with open(ta_func_header) as f:
     tmp = []
     for line in f:
+        if line.startswith('TA_LIB_API'):
+            line = line[10:]
         line = line.strip()
         if tmp or \
             line.startswith('TA_RetCode TA_') or \

--- a/tools/generate_stream.py
+++ b/tools/generate_stream.py
@@ -26,6 +26,8 @@ if not header_found:
 with open(ta_func_header) as f:
     tmp = []
     for line in f:
+        if line.startswith('TA_LIB_API'):
+            line = line[10:]
         line = line.strip()
         if tmp or \
             line.startswith('TA_RetCode TA_') or \


### PR DESCRIPTION
If one build the C lib from sources (sourceforge trunk) and install it - the ta_func.h header in /usr/local/include/ will contain function declarations like:
```
TA_LIB_API TA_RetCode TA_ACOS( int    startIdx, ...
....
TA_LIB_API TA_RetCode TA_S_ACOS( int    startIdx, ...
...
TA_LIB_API int TA_ACOS_Lookback( void );
```

while `generate_*.py` scripts are likely expecting declarations without `TA_LIB_API` prefix like inside `http://prdownloads.sourceforge.net/ta-lib/ta-lib-0.4.0-src.tar.gz` and unable to parse the header from trunk. Which makes addition of a new indicator even more complicated.   
This simple patch should make scripts compatible with both headers.