### PR TITLE
break threading for talib abstract with pandas

### DIFF
--- a/tools/threads_talib.py
+++ b/tools/threads_talib.py
@@ -1,44 +1,47 @@
 from __future__ import print_function
+import time
+import threading
 
 import numpy
-from numpy.testing import assert_array_equal
-import talib
+import copy
+from talib.abstract import RSI
 import sys
+import pandas as pd
 
-TEST_LEN = int(sys.argv[1]) if len(sys.argv) > 1 else 10000
+TEST_LEN_SHORT = int(sys.argv[1]) if len(sys.argv) > 1 else 999
+TEST_LEN_LONG = int(sys.argv[1]) if len(sys.argv) > 1 else 4005
 LOOPS = int(sys.argv[2]) if len(sys.argv) > 2 else 1000
 
-data = numpy.random.random(TEST_LEN)
+data_short = numpy.random.rand(TEST_LEN_SHORT, 5)
+data_long = numpy.random.rand(TEST_LEN_LONG, 5)
 
-ref1 = talib.MA(data)
-ref2, ref3, ref4 = talib.BBANDS(data)
-ref5 = talib.KAMA(data)
-ref6 = talib.CDLMORNINGDOJISTAR(data, data, data, data)
-
-import threading
+df_short = pd.DataFrame(data_short, columns={
+                        'open', 'high', 'low', 'close', 'volume'})
+df_long = pd.DataFrame(data_long, columns={
+                       'open', 'high', 'low', 'close', 'volume'})
 
 total = 0
 
+
 def loop():
     global total
+    if total % 2 == 0:
+        df = copy.deepcopy(df_short)
+    else:
+        df = copy.deepcopy(df_long)
+
     while total < LOOPS:
         total += 1
-        out1 = talib.MA(data)
-        assert_array_equal(out1, ref1)
-        out2, out3, out4 = talib.BBANDS(data)
-        assert_array_equal(out2, ref2)
-        assert_array_equal(out3, ref3)
-        assert_array_equal(out4, ref4)
-        out5 = talib.KAMA(data)
-        assert_array_equal(out5, ref5)
-        out6 = talib.CDLMORNINGDOJISTAR(data, data, data, data)
-        assert_array_equal(out6, ref6)
+        try:
+            df['RSI'] = RSI(df)
+        except ValueError as msg:
+            raise ValueError(msg)
 
-import time
+
 t0 = time.time()
 
 threads = []
-for i in range(10):
+for i in range(4):
     t = threading.Thread(target=loop)
     threads.append(t)
     t.start()
@@ -46,6 +49,6 @@ for i in range(10):
 for t in threads:
     t.join()
 t1 = time.time()
-print('test_len: %d, loops: %d' % (TEST_LEN, LOOPS))
+print('test_len: %d, loops: %d' % (TEST_LEN_LONG, LOOPS))
 print('%.6f' % (t1 - t0))
 print('%.6f' % ((t1 - t0) / LOOPS))

--- a/tools/threads_talib.py
+++ b/tools/threads_talib.py
@@ -25,7 +25,7 @@ total = 0
 
 def loop():
     global total
-    if total % 2 == 0:
+    if threading.get_native_id() % 2 == 0:
         df = copy.deepcopy(df_short)
     else:
         df = copy.deepcopy(df_long)


### PR DESCRIPTION
Illustrates #540 but does *not* solve the problem.

Over at freqtrade, we are using ta-lib in a multithreaded fashion and we have noticed that, on occasion, the library will throw an error that looks like this:

```
  File "/home/opc/freqtrade/user_data/strategies/EI3v2_RSI_CONS_TRAIL_AI.py", line 425, in populate_any_indicators
    informative[f"%-{coin}rsi-period_{t}"] = ta.RSI(informative, timeperiod=t)
  File "talib/_abstract.pxi", line 439, in talib._ta_lib.Function.__call__
  File "talib/_abstract.pxi", line 350, in talib._ta_lib.Function.outputs
  File "/home/opc/freqtrade/.env/lib64/python3.9/site-packages/pandas/core/series.py", line 442, in __init__
    com.require_length_match(data, index)
  File "/home/opc/freqtrade/.env/lib64/python3.9/site-packages/pandas/core/common.py", line 557, in require_length_match
    raise ValueError(
ValueError: Length of values (4005) does not match length of index (999)
```

Which is due to two threads simultaneously wanting to use `ta.RSI()` and using the ta.abstract interface.