### PR TITLE
Allow MA defaults other than SMA

### DIFF
--- a/tools/generate_func.py
+++ b/tools/generate_func.py
@@ -257,7 +257,10 @@ for f in functions:
                 else:
                     print('int %s=-2**31' % var, end=' ')   # TA_INTEGER_DEFAULT
             elif arg.startswith('TA_MAType'):
-                print('int %s=0' % var, end=' ')            # TA_MAType_SMA
+                if 'matype' in defaults:
+                    print('int %s=%s' % (var, defaults['matype']), end=' ')
+                else:
+                    print('int %s=0' % var, end=' ')            # TA_MAType_SMA
             else:
                 assert False, arg
             if '[, ' not in docs:

--- a/tools/generate_stream.py
+++ b/tools/generate_stream.py
@@ -124,7 +124,10 @@ for f in functions:
                 else:
                     print('int %s=-2**31' % var, end=' ')   # TA_INTEGER_DEFAULT
             elif arg.startswith('TA_MAType'):
-                print('int %s=0' % var, end=' ')            # TA_MAType_SMA
+                if 'matype' in defaults:
+                    print('int %s=%s' % (var, defaults['matype']), end=' ')
+                else:
+                    print('int %s=0' % var, end=' ')            # TA_MAType_SMA
             else:
                 assert False, arg
             if '[, ' not in docs:


### PR DESCRIPTION
In fact, currently there is no MA indicators in TA-Lib which use optInMAType argument defaults other than SMA(0), but I would like to add a support for such indicators, bcs I was going to add one for myself.
I hardcoded "matype" bcs `default_arg` contains "mAType".