### PR TITLE
Fix pytest error with pandas 1.5.0

### DIFF
--- a/talib/test_abstract.py
+++ b/talib/test_abstract.py
@@ -331,10 +331,8 @@ def test_threading():
     data_short = np.random.rand(TEST_LEN_SHORT, 5)
     data_long = np.random.rand(TEST_LEN_LONG, 5)
 
-    df_short = pd.DataFrame(data_short, columns={
-                            'open', 'high', 'low', 'close', 'volume'})
-    df_long = pd.DataFrame(data_long, columns={
-                           'open', 'high', 'low', 'close', 'volume'})
+    df_short = pd.DataFrame(data_short, columns=['open', 'high', 'low', 'close', 'volume'])
+    df_long = pd.DataFrame(data_long, columns=['open', 'high', 'low', 'close', 'volume'])
 
     total = 0
 


### PR DESCRIPTION
Pandas 1.5.0 is now raising an exception when the columns argument is a set. As such, the test should be adjusted to also work with the latest pandas version.

> [DataFrame](https://pandas.pydata.org/pandas-docs/dev/reference/api/pandas.DataFrame.html#pandas.DataFrame) constructor raises if index or columns arguments are sets ([GH47215](https://github.com/pandas-dev/pandas/issues/47215))

source: [pandas releaselog](https://pandas.pydata.org/pandas-docs/dev/whatsnew/v1.5.0.html#other-api-changes)

side note: Ci would currently be failing without this fix - since 1.5.0 is out (which happened on sept 19th).
