### PR TITLE
Clarify RSI lookback and unstable-period defaults in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,11 @@ parameters, unless specified as keyword arguments. Typically, these functions
 will have an initial "lookback" period (a required number of observations
 before an output is generated) set to `NaN`.
 
+The lookback is function-specific and does not always match the value passed
+to `timeperiod`. For example, `RSI(timeperiod=14)` needs 15 price observations
+because the first RSI value depends on 14 price changes between consecutive
+bars, not just 14 raw prices.
+
 For convenience, the Function API supports both `numpy.ndarray` and
 `pandas.Series` and `polars.Series` inputs.
 
@@ -432,6 +437,10 @@ Calculating momentum of the close prices, with a time period of 5:
 ```python
 output = talib.MOM(close, timeperiod=5)
 ```
+
+Functions marked in the docs as having an unstable period start with that
+extra unstable-period setting at `0`. In other words, `get_unstable_period()`
+returns `0` until you explicitly change it with `set_unstable_period()`.
 
 ### NaN's
 

--- a/docs/func.md
+++ b/docs/func.md
@@ -8,6 +8,10 @@ parameters, unless specified as keyword arguments. Typically, these functions
 will have an initial "lookback" period (a required number of observations
 before an output is generated) set to ``NaN``.
 
+The lookback is function-specific and may be larger than the `timeperiod`
+parameter. For example, ``RSI(timeperiod=14)`` needs 15 price observations,
+because the first RSI value is derived from 14 consecutive price changes.
+
 All of the following examples use the function API:
 
 ```python
@@ -36,6 +40,10 @@ Calculating momentum of the close prices, with a time period of 5:
 ```python
 output = talib.MOM(close, timeperiod=5)
 ```
+
+Functions documented as having an unstable period start with that extra
+unstable-period setting at ``0``. ``get_unstable_period()`` only returns a
+non-zero value after you set one explicitly with ``set_unstable_period()``.
 
 Documentation for all functions:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,10 @@ parameters, unless specified as keyword arguments. Typically, these functions
 will have an initial "lookback" period (a required number of observations
 before an output is generated) set to ``NaN``.
 
+The lookback is function-specific and may be larger than the `timeperiod`
+parameter. For example, ``RSI(timeperiod=14)`` needs 15 price observations,
+because the first RSI value is based on 14 consecutive price changes.
+
 All of the following examples use the function API:
 
 ```python
@@ -56,6 +60,10 @@ Calculating momentum of the close prices, with a time period of 5:
 ```python
 output = talib.MOM(close, timeperiod=5)
 ```
+
+Functions documented as having an unstable period start with that extra
+unstable-period setting at ``0``. ``get_unstable_period()`` only reports a
+non-zero value after you call ``set_unstable_period()`` yourself.
 
 ## Abstract API Quick Start
 


### PR DESCRIPTION
Fixes #603.
Also addresses #664.

The function docs already mention lookback periods and unstable functions, but they do not explain two points that keep coming up in issues:

- `timeperiod` is not always the same as the number of raw observations needed before the first output. `RSI(timeperiod=14)` needs 15 prices because it starts from 14 price changes.
- `get_unstable_period()` returns `0` by default, even for functions documented as unstable, until the caller sets a non-zero unstable period explicitly.

This adds those clarifications to the main Function API docs in the README and generated docs pages.
