### PR TITLE
Fix linux CI wheelbuilder 

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -31,7 +31,8 @@ jobs:
               bash ./tools/build_talib_linux.sh
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
           CIBW_MUSLLINUX_X86_64_IMAGE: musllinux_1_2
-          CIBW_ENVIRONMENT_PASS_LINUX: TALIB_C_VER
+          CIBW_ENVIRONMENT_PASS_LINUX: TALIB_C_VER CFLAGS
+          CFLAGS: -D_GNU_SOURCE
           CIBW_TEST_SKIP: "cp*-musllinux*"
           CIBW_TEST_COMMAND: >
             cd .. &&
@@ -66,7 +67,8 @@ jobs:
               bash ./tools/build_talib_linux.sh
           CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
           CIBW_MUSLLINUX_AARCH64_IMAGE: musllinux_1_2
-          CIBW_ENVIRONMENT_PASS_LINUX: TALIB_C_VER
+          CIBW_ENVIRONMENT_PASS_LINUX: TALIB_C_VER CFLAGS
+          CFLAGS: -D_GNU_SOURCE
           CIBW_TEST_SKIP: "cp*-musllinux*"
           CIBW_TEST_COMMAND: >
             cd .. &&

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -31,6 +31,7 @@ jobs:
               bash ./tools/build_talib_linux.sh
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
           CIBW_MUSLLINUX_X86_64_IMAGE: musllinux_1_2
+          CIBW_ENVIRONMENT_PASS_LINUX: TALIB_C_VER
           CIBW_TEST_SKIP: "cp*-musllinux*"
           CIBW_TEST_COMMAND: >
             cd .. &&
@@ -65,6 +66,7 @@ jobs:
               bash ./tools/build_talib_linux.sh
           CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
           CIBW_MUSLLINUX_AARCH64_IMAGE: musllinux_1_2
+          CIBW_ENVIRONMENT_PASS_LINUX: TALIB_C_VER
           CIBW_TEST_SKIP: "cp*-musllinux*"
           CIBW_TEST_COMMAND: >
             cd .. &&


### PR DESCRIPTION
For linux, environment variables must be passed in explicitly, otherwise they'll be missing from the build environment.

Apparently non-linux wheels were unaffected - which the wheel [build logs](https://github.com/TA-Lib/ta-lib-python/actions/runs/28686860872) for the release also confirm.

closes #750

**edit** saw that you bumped the version in build scripts - which is a good quick workaround - but prone to error with the next c library bump - this is the more reliable or permanent fix ... 